### PR TITLE
refactor: modular binary parser + config-driven test framework

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -1,0 +1,32 @@
+name: Setup Rust
+description: 'Setup Rust toolchain with caching'
+
+inputs:
+  toolchain:
+    description: 'Rust toolchain version'
+    default: 'stable'
+  components:
+    description: 'Additional components to install (comma-separated)'
+    default: ''
+  targets:
+    description: 'Additional targets to install (comma-separated)'
+    default: ''
+  cache-key:
+    description: 'Additional cache key suffix'
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: ${{ inputs.toolchain }}
+        components: ${{ inputs.components }}
+        targets: ${{ inputs.targets }}
+
+    - name: Setup Rust cache
+      uses: Swatinem/rust-cache@v2
+      with:
+        key: ${{ inputs.cache-key }}
+

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,0 +1,100 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+env:
+  PROJECT_NAME: ${{ github.event.repository.name }}
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build (${{ matrix.target }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+          - os: windows-latest
+            target: aarch64-pc-windows-msvc
+          - os: macos-latest
+            target: x86_64-apple-darwin
+          - os: macos-latest
+            target: aarch64-apple-darwin
+          # - os: ubuntu-latest
+          #   target: x86_64-unknown-linux-gnu
+          # - os: ubuntu-latest
+          #   target: aarch64-unknown-linux-gnu
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Setup Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
+
+      - name: Build binary
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Strip binary (macOS & Linux)
+        if: runner.os != 'Windows'
+        run: strip "target/${{ matrix.target }}/release/${{ env.PROJECT_NAME }}"
+
+      - name: Package artifact
+        shell: bash
+        run: |
+          staging_dir="staging"
+          mkdir -p "${staging_dir}"
+          
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            binary_name="${{ env.PROJECT_NAME }}.exe"
+            archive_name="${{ env.PROJECT_NAME }}-${{ matrix.target }}.zip"
+            cp "target/${{ matrix.target }}/release/${binary_name}" "${staging_dir}/"
+            cd "${staging_dir}"
+            7z a "../${archive_name}" .
+            cd ..
+          else
+            binary_name="${{ env.PROJECT_NAME }}"
+            archive_name="${{ env.PROJECT_NAME }}-${{ matrix.target }}.tar.gz"
+            cp "target/${{ matrix.target }}/release/${binary_name}" "${staging_dir}/"
+            tar -czvf "${archive_name}" -C "${staging_dir}" .
+          fi
+          
+          echo "ARCHIVE_PATH=${archive_name}" >> $GITHUB_ENV
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.PROJECT_NAME }}-${{ matrix.target }}
+          path: ${{ env.ARCHIVE_PATH }}
+          if-no-files-found: error
+
+  release:
+    name: Create Release
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts/
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: artifacts/**/*
+          name: Release ${{ github.ref_name }}
+          generate_release_notes: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,8 +49,10 @@ jobs:
         id: cache-fixtures
         uses: actions/cache@v4
         with:
-          path: tests/fixtures
-          key: fixtures-all-v1
+          path: |
+            tests/fixtures/*_app
+            tests/fixtures/*_win
+          key: fixtures-v2-${{ hashFiles('tests/fixtures/fixtures.toml') }}
 
       - name: Download fixtures
         if: steps.cache-fixtures.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,62 @@
+name: CI
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  fmt:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-rust
+        with:
+          components: rustfmt
+      - run: cargo fmt --all -- --check
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-rust
+        with:
+          components: clippy
+          cache-key: clippy
+      - run: cargo clippy --all-targets -- -D warnings
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    needs: [clippy]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-rust
+        with:
+          cache-key: test
+
+      - name: Install p7zip
+        run: sudo apt-get update && sudo apt-get install -y p7zip-full
+
+      - name: Cache fixtures
+        id: cache-fixtures
+        uses: actions/cache@v4
+        with:
+          path: tests/fixtures
+          key: fixtures-all-v1
+
+      - name: Download fixtures
+        if: steps.cache-fixtures.outputs.cache-hit != 'true'
+        run: ./scripts/download-fixtures.sh
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Run tests
+        run: cargo test --release -- --nocapture

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Build and Release
+name: Release
 
 on:
   push:
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   build:
-    name: Build on ${{ matrix.os }} (${{ matrix.target }})
+    name: Build (${{ matrix.target }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -33,24 +33,20 @@ jobs:
           #   target: aarch64-unknown-linux-gnu
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          profile: minimal
-          override: true
-          target: ${{ matrix.target }}
+          targets: ${{ matrix.target }}
+
+      - name: Setup Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
 
       - name: Build binary
-        run: cargo build --verbose --release --target ${{ matrix.target }}
-        env:
-          RUST_BACKTRACE: 1
+        run: cargo build --release --target ${{ matrix.target }}
 
       - name: Strip binary (macOS & Linux)
         if: runner.os != 'Windows'
@@ -73,7 +69,6 @@ jobs:
             binary_name="${{ env.PROJECT_NAME }}"
             archive_name="${{ env.PROJECT_NAME }}-${{ matrix.target }}.tar.gz"
             cp "target/${{ matrix.target }}/release/${binary_name}" "${staging_dir}/"
-            # cp README.md LICENSE "${staging_dir}/"
             tar -czvf "${archive_name}" -C "${staging_dir}" .
           fi
           
@@ -87,12 +82,12 @@ jobs:
           if-no-files-found: error
 
   release:
-    name: Create GitHub Release
+    name: Create Release
     needs: build
     runs-on: ubuntu-latest
-    
+
     steps:
-      - name: Download all build artifacts
+      - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
           path: artifacts/

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /target
+
+tests/fixtures/
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 /target
 
-tests/fixtures/
+# Ignore downloaded fixture binaries, but keep fixtures.toml
+tests/fixtures/*
+!tests/fixtures/fixtures.toml
+
 .vscode/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,10 +80,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 
 [[package]]
-name = "brotli"
-version = "7.0.0"
+name = "bitflags"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc97b8f16f944bba54f0433f07e30be199b6dc2bd25937444bbad560bcea29bd"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+
+[[package]]
+name = "brotli"
+version = "8.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -92,9 +98,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "4.0.2"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74fa05ad7d803d413eb8380983b092cbbaf9a85f151b871360e7b00cd7060b37"
+checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -162,6 +168,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "flate2"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -172,10 +200,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "indexmap"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -185,9 +241,15 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "libc"
-version = "0.2.170"
+version = "0.2.179"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
+checksum = "c5a2d376baa530d1238d133232d15e239abad80d05838b4b59354e5268af431f"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "memchr"
@@ -221,9 +283,9 @@ checksum = "f5438dd2b2ff4c6df6e1ce22d825ed2fa93ee2922235cc45186991717f0a892d"
 
 [[package]]
 name = "object"
-version = "0.36.7"
+version = "0.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+checksum = "271638cd5fa9cca89c4c304675ca658efc4e64a66c716b7cfe1afb4b9611dbbc"
 dependencies = [
  "flate2",
  "memchr",
@@ -255,19 +317,71 @@ dependencies = [
 ]
 
 [[package]]
-name = "ruzstd"
-version = "0.7.3"
+name = "r-efi"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fad02996bfc73da3e301efe90b1837be9ed8f4a462b6ed410aa35d00381de89f"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rustix"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
+name = "ruzstd"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ff0cc5e135c8870a775d3320910cd9b564ec036b4dc0b8741629020be63f01"
 dependencies = [
  "twox-hash",
 ]
 
 [[package]]
-name = "static_assertions"
-version = "1.1.0"
+name = "serde"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "strsim"
@@ -288,7 +402,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-dumper"
-version = "0.1.4-alpha"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "brotli",
@@ -296,17 +410,68 @@ dependencies = [
  "memmap2",
  "normalize-path",
  "object",
+ "serde",
+ "tempfile",
+ "toml",
 ]
 
 [[package]]
-name = "twox-hash"
-version = "1.6.3"
+name = "tempfile"
+version = "3.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
+checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
 dependencies = [
- "cfg-if",
- "static_assertions",
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
 ]
+
+[[package]]
+name = "toml"
+version = "0.9.10+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0825052159284a1a8b4d6c0c86cbc801f2da5afd2b225fa548c72f2e74002f48"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.6+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.0.6+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
+
+[[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "unicode-ident"
@@ -319,6 +484,15 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "windows-sys"
@@ -392,3 +566,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tauri-dumper"
-version = "0.1.4-alpha"
+version = "0.1.5"
 edition = "2021"
 authors = ["Mason Shi <fishilir@gmail.com>"]
 license = "MIT"
@@ -11,14 +11,23 @@ exclude = [".cargo/*", ".github/*"]
 keywords = ["reverse-engineering", "tauri-application", "asset-decompressor", "asset-unpacker"]
 
 
+[lib]
+name = "tauri_dumper"
+path = "src/lib.rs"
+
 [[bin]]
 name = "tauri-dumper"
 path = "src/main.rs"
 
 [dependencies]
-object = "0.36"
+object = "0.38"
 memmap2 = "0.9"
-brotli = "7.0"
+brotli = "8.0"
 anyhow = "1.0"
 clap = { version = "4.5", features = ["derive"] }
-normalize-path = "0.2.1"
+normalize-path = "0.2"
+
+[dev-dependencies]
+tempfile = "3.24"
+toml = "0.9"
+serde = { version = "1.0", features = ["derive"] }

--- a/scripts/download-fixtures.sh
+++ b/scripts/download-fixtures.sh
@@ -1,0 +1,180 @@
+#!/bin/bash
+# Download test fixtures for integration tests.
+# Configuration: tests/fixtures/fixtures.toml
+# Requires: gh (GitHub CLI), 7z (for PE extraction)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$SCRIPT_DIR/.."
+FIXTURES_DIR="$PROJECT_ROOT/tests/fixtures"
+CONFIG_FILE="$FIXTURES_DIR/fixtures.toml"
+
+# =============================================================================
+# Configuration Parser
+# =============================================================================
+
+# Get field value for fixture at given index
+get_field() {
+    local index="$1"
+    local field="$2"
+    
+    awk -v idx="$index" -v field="$field" '
+        BEGIN { count = -1; in_block = 0 }
+        /^\[\[fixture\]\]/ { count++; in_block = (count == idx) }
+        in_block && $0 ~ "^" field " *= *\"" { 
+            gsub(/^[a-z_]+ *= *"/, ""); 
+            gsub(/"$/, ""); 
+            print; 
+            exit 
+        }
+        in_block && /^\[\[/ && !/^\[\[fixture\]\]/ { in_block = 0 }
+    ' "$CONFIG_FILE"
+}
+
+# Count total fixtures
+count_fixtures() {
+    grep -c '^\[\[fixture\]\]' "$CONFIG_FILE" 2>/dev/null || echo 0
+}
+
+# =============================================================================
+# Download Functions
+# =============================================================================
+
+download_macho() {
+    local name="$1" repo="$2" version="$3" pattern="$4" extract_dir="$5" binary="$6"
+    
+    local target_dir="$FIXTURES_DIR/$extract_dir"
+    local binary_path="$target_dir/$binary"
+    
+    if [ -f "$binary_path" ]; then
+        echo "✅ $name (macho) - already exists"
+        return 0
+    fi
+    
+    echo "⬇️  Downloading $name (macho)..."
+    mkdir -p "$target_dir"
+    
+    gh release download "$version" \
+        --repo "$repo" \
+        --pattern "$pattern" \
+        --dir "$FIXTURES_DIR" --clobber
+    
+    tar -xzf "$FIXTURES_DIR/$pattern" -C "$target_dir"
+    rm -f "$FIXTURES_DIR/$pattern"
+    
+    if [ -f "$binary_path" ]; then
+        echo "✅ $name (macho) - downloaded"
+    else
+        echo "❌ $name (macho) - binary not found: $binary"
+        return 1
+    fi
+}
+
+download_pe() {
+    local name="$1" repo="$2" version="$3" pattern="$4" extract_dir="$5" binary="$6"
+    
+    if ! command -v 7z &> /dev/null; then
+        echo "⚠️  7z not found. Skipping PE: $name"
+        echo "   Install: brew install p7zip (macOS) / apt install p7zip-full (Linux)"
+        return 0
+    fi
+    
+    local target_dir="$FIXTURES_DIR/$extract_dir"
+    local binary_path="$target_dir/$binary"
+    
+    if [ -f "$binary_path" ]; then
+        echo "✅ $name (pe) - already exists"
+        return 0
+    fi
+    
+    echo "⬇️  Downloading $name (pe)..."
+    mkdir -p "$target_dir"
+    
+    gh release download "$version" \
+        --repo "$repo" \
+        --pattern "$pattern" \
+        --dir "$FIXTURES_DIR" --clobber
+    
+    # Extract from NSIS installer
+    local temp_dir
+    temp_dir=$(mktemp -d)
+    7z x "$FIXTURES_DIR/$pattern" -o"$temp_dir" -y > /dev/null
+    
+    local found_exe
+    found_exe=$(find "$temp_dir" -iname "$binary" -type f | head -1 || true)
+    
+    if [ -n "$found_exe" ]; then
+        cp "$found_exe" "$binary_path"
+        echo "✅ $name (pe) - downloaded"
+    else
+        echo "❌ $name (pe) - binary not found in installer: $binary"
+        find "$temp_dir" -name "*.exe" -type f
+        rm -rf "$temp_dir"
+        rm -f "$FIXTURES_DIR/$pattern"
+        return 1
+    fi
+    
+    rm -rf "$temp_dir"
+    rm -f "$FIXTURES_DIR/$pattern"
+}
+
+# =============================================================================
+# Main
+# =============================================================================
+
+download_fixture() {
+    local index="$1"
+    
+    local name format repo version pattern extract_dir binary
+    name=$(get_field "$index" "name")
+    format=$(get_field "$index" "format")
+    repo=$(get_field "$index" "repo")
+    version=$(get_field "$index" "version")
+    pattern=$(get_field "$index" "pattern")
+    extract_dir=$(get_field "$index" "extract_dir")
+    binary=$(get_field "$index" "binary")
+    
+    case "$format" in
+        macho)
+            download_macho "$name" "$repo" "$version" "$pattern" "$extract_dir" "$binary"
+            ;;
+        pe)
+            download_pe "$name" "$repo" "$version" "$pattern" "$extract_dir" "$binary"
+            ;;
+        *)
+            echo "⚠️  Unknown format: $format (fixture: $name)"
+            ;;
+    esac
+}
+
+main() {
+    local filter="${1:-}"
+    
+    echo "📦 Test Fixtures Downloader"
+    echo "   Config: $CONFIG_FILE"
+    echo ""
+    
+    mkdir -p "$FIXTURES_DIR"
+    
+    local count
+    count=$(count_fixtures)
+    
+    for ((i=0; i<count; i++)); do
+        local format name
+        format=$(get_field "$i" "format")
+        name=$(get_field "$i" "name")
+        
+        # Filter by format if specified
+        if [ -n "$filter" ] && [ "$filter" != "$format" ]; then
+            continue
+        fi
+        
+        download_fixture "$i"
+    done
+    
+    echo ""
+    echo "🎉 Done! Run: cargo test"
+}
+
+main "$@"

--- a/scripts/download-fixtures.sh
+++ b/scripts/download-fixtures.sh
@@ -67,6 +67,10 @@ download_macho() {
         echo "✅ $name (macho) - downloaded"
     else
         echo "❌ $name (macho) - binary not found: $binary"
+        echo "   Expected path: $binary_path"
+        echo "   Directory contents:"
+        find "$target_dir" -type f -name "*.app" -o -type d -name "*.app" 2>/dev/null | head -10 || true
+        ls -la "$target_dir" 2>/dev/null || true
         return 1
     fi
 }

--- a/src/binary/macho.rs
+++ b/src/binary/macho.rs
@@ -125,4 +125,3 @@ impl BinaryParser for MachOParser {
         })
     }
 }
-

--- a/src/binary/macho.rs
+++ b/src/binary/macho.rs
@@ -1,0 +1,128 @@
+//! Mach-O binary format parser.
+
+use super::{BinaryParser, ScanRange, SectionInfo};
+use anyhow::{anyhow, Context, Result};
+use object::macho::{MachHeader64, SegmentCommand64, LC_DYLD_CHAINED_FIXUPS, LC_SEGMENT_64};
+use object::read::macho::MachHeader;
+use object::Endianness;
+
+/// Mach-O pointer fixup format.
+///
+/// Modern macOS binaries use chained fixups, while older ones use traditional rebase.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FixupFormat {
+    /// Modern chained fixups (LC_DYLD_CHAINED_FIXUPS).
+    ///
+    /// Pointer format: high bits contain metadata, low 43 bits contain offset from image base.
+    ChainedFixups,
+
+    /// Traditional rebase format (LC_DYLD_INFO_ONLY).
+    ///
+    /// Pointer value is the actual virtual address.
+    Traditional,
+}
+
+/// Mach-O binary parser with support for both chained fixups and traditional formats.
+pub struct MachOParser {
+    sections: Vec<SectionInfo>,
+    fixup_format: FixupFormat,
+    image_base: u64,
+}
+
+impl MachOParser {
+    /// Creates a new Mach-O parser from raw binary data.
+    pub fn new(data: &[u8], sections: Vec<SectionInfo>) -> Result<Self> {
+        let (fixup_format, image_base) = Self::detect_fixup_format(data)?;
+
+        Ok(Self {
+            sections,
+            fixup_format,
+            image_base,
+        })
+    }
+
+    /// Detects the fixup format by analyzing load commands.
+    fn detect_fixup_format(data: &[u8]) -> Result<(FixupFormat, u64)> {
+        let header = MachHeader64::<Endianness>::parse(data, 0)
+            .map_err(|e| anyhow!("Failed to parse Mach-O header: {}", e))?;
+
+        let endian = header.endian().context("Failed to get endianness")?;
+
+        let mut load_commands = header
+            .load_commands(endian, data, 0)
+            .map_err(|e| anyhow!("Failed to parse load commands: {}", e))?;
+
+        let mut has_chained_fixups = false;
+        let mut image_base = 0x100000000u64; // Default for 64-bit Mach-O
+
+        while let Some(cmd) = load_commands.next()? {
+            match cmd.cmd() {
+                LC_DYLD_CHAINED_FIXUPS => {
+                    has_chained_fixups = true;
+                }
+                LC_SEGMENT_64 => {
+                    if let Ok(segment) = cmd.data::<SegmentCommand64<Endianness>>() {
+                        if segment.segname == *b"__TEXT\0\0\0\0\0\0\0\0\0\0" {
+                            image_base = segment.vmaddr.get(endian);
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        let format = if has_chained_fixups {
+            FixupFormat::ChainedFixups
+        } else {
+            FixupFormat::Traditional
+        };
+
+        Ok((format, image_base))
+    }
+
+    /// Decodes a raw pointer to get the actual virtual address.
+    fn decode_pointer(&self, raw_ptr: u64) -> u64 {
+        match self.fixup_format {
+            FixupFormat::ChainedFixups => {
+                // Chained fixups: low 43 bits contain offset from image base
+                const TARGET_MASK: u64 = 0x7FFFFFFFFFF;
+                let offset = raw_ptr & TARGET_MASK;
+                self.image_base + offset
+            }
+            FixupFormat::Traditional => {
+                // Traditional: pointer is the actual virtual address
+                raw_ptr
+            }
+        }
+    }
+
+    /// Converts a virtual address to a file offset.
+    fn va_to_file_offset(&self, va: u64) -> Result<u64> {
+        self.sections
+            .iter()
+            .find(|s| va >= s.virtual_address && va < s.virtual_address + s.size)
+            .map(|s| va - s.virtual_address + s.file_offset)
+            .ok_or_else(|| anyhow!("Virtual address {:#X} not found in any section", va))
+    }
+}
+
+impl BinaryParser for MachOParser {
+    fn resolve_pointer(&self, raw_ptr: u64) -> Result<u64> {
+        let va = self.decode_pointer(raw_ptr);
+        self.va_to_file_offset(va)
+    }
+
+    fn scan_range(&self) -> Result<ScanRange> {
+        // Asset headers are stored in __DATA_CONST,__const section (last in our list)
+        let section = self
+            .sections
+            .last()
+            .context("No sections found for scanning")?;
+
+        Ok(ScanRange {
+            start: section.file_offset as usize,
+            length: section.size as usize,
+        })
+    }
+}
+

--- a/src/binary/mod.rs
+++ b/src/binary/mod.rs
@@ -1,0 +1,98 @@
+//! Binary format parsing abstractions.
+//!
+//! This module provides a unified interface for parsing different binary formats
+//! (PE, Mach-O) with format-specific pointer resolution strategies.
+
+mod macho;
+mod pe;
+
+use anyhow::Result;
+use object::{BinaryFormat, Object, ObjectSection};
+
+pub use macho::MachOParser;
+pub use pe::PeParser;
+
+/// Information about a section in the binary.
+#[derive(Debug, Clone)]
+pub struct SectionInfo {
+    pub virtual_address: u64,
+    pub file_offset: u64,
+    pub size: u64,
+}
+
+/// Defines the scan range for asset searching.
+#[derive(Debug, Clone, Copy)]
+pub struct ScanRange {
+    pub start: usize,
+    pub length: usize,
+}
+
+/// Trait for binary format-specific parsing operations.
+///
+/// Different binary formats (PE, Mach-O) have different ways of storing
+/// and resolving pointers. This trait abstracts those differences.
+pub trait BinaryParser: Send + Sync {
+    /// Converts a raw pointer value from the binary to a file offset.
+    ///
+    /// This handles format-specific pointer encoding (e.g., Mach-O chained fixups).
+    fn resolve_pointer(&self, raw_ptr: u64) -> Result<u64>;
+
+    /// Returns the scan range for searching assets in the binary.
+    fn scan_range(&self) -> Result<ScanRange>;
+}
+
+/// Creates the appropriate binary parser based on the detected format.
+pub fn create_parser(data: &[u8]) -> Result<Box<dyn BinaryParser>> {
+    let obj = object::File::parse(data)?;
+
+    match obj.format() {
+        BinaryFormat::Pe => {
+            let sections = collect_pe_sections(&obj);
+            Ok(Box::new(PeParser::new(sections)?))
+        }
+        BinaryFormat::MachO => {
+            let sections = collect_macho_sections(&obj);
+            Ok(Box::new(MachOParser::new(data, sections)?))
+        }
+        other => anyhow::bail!("Unsupported binary format: {:?}", other),
+    }
+}
+
+fn collect_pe_sections<'a>(obj: &object::File<'a>) -> Vec<SectionInfo> {
+    obj.sections()
+        .filter(|s| {
+            s.name() == Ok(".rdata") && s.kind() == object::SectionKind::ReadOnlyData
+        })
+        .filter_map(|s| {
+            Some(SectionInfo {
+                virtual_address: s.address(),
+                file_offset: s.file_range()?.0,
+                size: s.size(),
+            })
+        })
+        .collect()
+}
+
+fn collect_macho_sections<'a>(obj: &object::File<'a>) -> Vec<SectionInfo> {
+    // Collect __const sections from relevant segments:
+    // - __TEXT,__const: contains string literals (asset names and data)
+    // - __DATA_CONST,__const: contains asset headers (modern layout)
+    // - __DATA,__const: contains asset headers (alternative layout)
+    obj.sections()
+        .filter(|s| {
+            matches!(
+                s.segment_name(),
+                Ok(Some("__TEXT")) | Ok(Some("__DATA_CONST")) | Ok(Some("__DATA"))
+            )
+        })
+        .filter(|s| s.name() == Ok("__const"))
+        .filter_map(|s| {
+            Some(SectionInfo {
+                virtual_address: s.address(),
+                file_offset: s.file_range()?.0,
+                size: s.size(),
+            })
+        })
+        .collect()
+}
+

--- a/src/binary/mod.rs
+++ b/src/binary/mod.rs
@@ -60,9 +60,7 @@ pub fn create_parser(data: &[u8]) -> Result<Box<dyn BinaryParser>> {
 
 fn collect_pe_sections<'a>(obj: &object::File<'a>) -> Vec<SectionInfo> {
     obj.sections()
-        .filter(|s| {
-            s.name() == Ok(".rdata") && s.kind() == object::SectionKind::ReadOnlyData
-        })
+        .filter(|s| s.name() == Ok(".rdata") && s.kind() == object::SectionKind::ReadOnlyData)
         .filter_map(|s| {
             Some(SectionInfo {
                 virtual_address: s.address(),
@@ -95,4 +93,3 @@ fn collect_macho_sections<'a>(obj: &object::File<'a>) -> Vec<SectionInfo> {
         })
         .collect()
 }
-

--- a/src/binary/pe.rs
+++ b/src/binary/pe.rs
@@ -1,0 +1,47 @@
+//! PE (Portable Executable) binary format parser.
+
+use super::{BinaryParser, ScanRange, SectionInfo};
+use anyhow::{anyhow, Context, Result};
+
+/// PE binary parser.
+pub struct PeParser {
+    sections: Vec<SectionInfo>,
+}
+
+impl PeParser {
+    /// Creates a new PE parser with the given sections.
+    pub fn new(sections: Vec<SectionInfo>) -> Result<Self> {
+        if sections.is_empty() {
+            anyhow::bail!("No .rdata section found in PE file");
+        }
+        Ok(Self { sections })
+    }
+}
+
+impl BinaryParser for PeParser {
+    fn resolve_pointer(&self, raw_ptr: u64) -> Result<u64> {
+        // PE pointers are virtual addresses relative to image base
+        let section = self.sections.first().context("No sections available")?;
+
+        if raw_ptr >= section.virtual_address
+            && raw_ptr < section.virtual_address + section.size
+        {
+            Ok(raw_ptr - section.virtual_address + section.file_offset)
+        } else {
+            Err(anyhow!("Pointer {:#X} outside .rdata section bounds", raw_ptr))
+        }
+    }
+
+    fn scan_range(&self) -> Result<ScanRange> {
+        let section = self
+            .sections
+            .first()
+            .context("No sections found for scanning")?;
+
+        Ok(ScanRange {
+            start: section.file_offset as usize,
+            length: section.size as usize,
+        })
+    }
+}
+

--- a/src/binary/pe.rs
+++ b/src/binary/pe.rs
@@ -23,12 +23,13 @@ impl BinaryParser for PeParser {
         // PE pointers are virtual addresses relative to image base
         let section = self.sections.first().context("No sections available")?;
 
-        if raw_ptr >= section.virtual_address
-            && raw_ptr < section.virtual_address + section.size
-        {
+        if raw_ptr >= section.virtual_address && raw_ptr < section.virtual_address + section.size {
             Ok(raw_ptr - section.virtual_address + section.file_offset)
         } else {
-            Err(anyhow!("Pointer {:#X} outside .rdata section bounds", raw_ptr))
+            Err(anyhow!(
+                "Pointer {:#X} outside .rdata section bounds",
+                raw_ptr
+            ))
         }
     }
 
@@ -44,4 +45,3 @@ impl BinaryParser for PeParser {
         })
     }
 }
-

--- a/src/dumper.rs
+++ b/src/dumper.rs
@@ -156,4 +156,3 @@ impl Dumper {
         Ok(decompressed)
     }
 }
-

--- a/src/dumper.rs
+++ b/src/dumper.rs
@@ -1,0 +1,159 @@
+//! Asset dumper for Tauri applications.
+
+use crate::binary::{self, BinaryParser};
+use anyhow::{anyhow, Result};
+use memmap2::Mmap;
+use std::fs::File;
+use std::io::{Cursor, Read};
+
+/// Size of the asset header structure in bytes.
+const ASSET_HEADER_SIZE: usize = size_of::<AssetHeader>();
+
+/// Raw asset header as stored in the binary.
+#[repr(C)]
+#[derive(Debug)]
+struct AssetHeader {
+    name_ptr: u64,
+    name_len: u64,
+    data_ptr: u64,
+    data_size: u64,
+}
+
+/// A parsed asset with its name and compressed data.
+#[derive(Debug)]
+pub struct Asset {
+    pub name: String,
+    pub data: Vec<u8>,
+}
+
+/// Extracts embedded assets from Tauri application binaries.
+pub struct Dumper {
+    mmap: Mmap,
+    parser: Box<dyn BinaryParser>,
+}
+
+impl Dumper {
+    /// Creates a new dumper for the given file.
+    pub fn new(file: File) -> Result<Self> {
+        let mmap = unsafe { Mmap::map(&file)? };
+        let parser = binary::create_parser(&mmap)?;
+
+        Ok(Self { mmap, parser })
+    }
+
+    /// Scans the binary for embedded assets.
+    pub fn scan_assets(&self) -> Result<Vec<Asset>> {
+        let range = self.parser.scan_range()?;
+        let end = range.start.saturating_add(range.length);
+
+        assert!(end <= self.mmap.len(), "Scan range exceeds file bounds");
+
+        let mut assets = Vec::new();
+        let mut offset = range.start;
+        let mut step = 8; // Initial alignment
+
+        while offset + ASSET_HEADER_SIZE <= end {
+            if let Ok(asset) = self.try_parse_asset(offset) {
+                assets.push(asset);
+                step = ASSET_HEADER_SIZE; // Align to header size after finding an asset
+            }
+            offset += step;
+        }
+
+        Ok(assets)
+    }
+
+    /// Attempts to parse an asset at the given file offset.
+    fn try_parse_asset(&self, offset: usize) -> Result<Asset> {
+        let header = self.read_header(offset)?;
+
+        let name_offset = self.parser.resolve_pointer(header.name_ptr)?;
+        let data_offset = self.parser.resolve_pointer(header.data_ptr)?;
+
+        self.validate_pointers(name_offset, header.name_len, data_offset, header.data_size)?;
+
+        let name = self.read_name(name_offset as usize, header.name_len as usize)?;
+        let data = self.read_data(data_offset as usize, header.data_size as usize)?;
+
+        Ok(Asset { name, data })
+    }
+
+    /// Reads an asset header from the given offset.
+    fn read_header(&self, offset: usize) -> Result<&AssetHeader> {
+        if offset + ASSET_HEADER_SIZE > self.mmap.len() {
+            return Err(anyhow!("Header offset out of bounds"));
+        }
+
+        let chunk = &self.mmap[offset..offset + ASSET_HEADER_SIZE];
+        Ok(unsafe { &*(chunk.as_ptr() as *const AssetHeader) })
+    }
+
+    /// Validates that the pointers point to valid data.
+    fn validate_pointers(
+        &self,
+        name_offset: u64,
+        name_len: u64,
+        data_offset: u64,
+        data_size: u64,
+    ) -> Result<()> {
+        let name_off = name_offset as usize;
+        let data_off = data_offset as usize;
+        let name_len = name_len as usize;
+        let data_size = data_size as usize;
+
+        // Bounds check
+        if name_off >= self.mmap.len()
+            || name_off.saturating_add(name_len) > self.mmap.len()
+            || data_off >= self.mmap.len()
+            || data_off.saturating_add(data_size) > self.mmap.len()
+        {
+            return Err(anyhow!("Pointer out of file bounds"));
+        }
+
+        // Name must start with '/'
+        if self.mmap[name_off] != b'/' {
+            return Err(anyhow!("Invalid asset name format"));
+        }
+
+        // Data must be valid brotli-compressed
+        self.verify_brotli(&self.mmap[data_off..data_off + data_size])?;
+
+        Ok(())
+    }
+
+    /// Verifies that data is valid brotli-compressed content.
+    fn verify_brotli(&self, data: &[u8]) -> Result<()> {
+        let mut decompressor = brotli::Decompressor::new(data, data.len());
+        let mut buf = Vec::new();
+        decompressor
+            .read_to_end(&mut buf)
+            .map_err(|_| anyhow!("Invalid brotli data"))?;
+        Ok(())
+    }
+
+    /// Reads the asset name from the given offset.
+    fn read_name(&self, offset: usize, len: usize) -> Result<String> {
+        let bytes = &self.mmap[offset..offset + len];
+
+        if !bytes.iter().all(|&b| b.is_ascii()) {
+            return Err(anyhow!("Asset name contains non-ASCII characters"));
+        }
+
+        String::from_utf8(bytes.to_vec()).map_err(Into::into)
+    }
+
+    /// Reads the compressed asset data from the given offset.
+    fn read_data(&self, offset: usize, len: usize) -> Result<Vec<u8>> {
+        Ok(self.mmap[offset..offset + len].to_vec())
+    }
+
+    /// Decompresses an asset's data.
+    pub fn decompress_asset(&self, asset: &Asset) -> Result<Vec<u8>> {
+        let reader = Cursor::new(&asset.data);
+        let mut decompressor = brotli::Decompressor::new(reader, asset.data.len());
+        let mut decompressed = Vec::new();
+        decompressor.read_to_end(&mut decompressed)?;
+        Ok(decompressed)
+    }
+}
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,9 @@
+//! Tauri asset dumper library.
+//!
+//! This library provides functionality to extract embedded assets from Tauri application binaries.
+
+pub mod binary;
+pub mod dumper;
+
+pub use dumper::{Asset, Dumper};
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,4 +6,3 @@ pub mod binary;
 pub mod dumper;
 
 pub use dumper::{Asset, Dumper};
-

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,35 +1,9 @@
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, Result};
 use clap::Parser;
-use memmap2::Mmap;
 use normalize_path::NormalizePath;
-use object::{BinaryFormat, Object, ObjectSection, SectionKind};
+use tauri_dumper::Dumper;
 use std::fs::{self, File};
-use std::io::{Cursor, Read};
 use std::path::Path;
-
-const ASSET_HEADER_SIZE: usize = size_of::<AssetHeader>();
-
-#[repr(C)]
-#[derive(Debug)]
-struct AssetHeader {
-    name_ptr: u64,
-    name_len: u64,
-    data_ptr: u64,
-    data_size: u64,
-}
-
-#[derive(Debug)]
-struct Asset {
-    name: String,
-    data: Vec<u8>,
-}
-
-#[derive(Debug)]
-struct SectionInfo {
-    virtual_address: u64,
-    file_offset: u64,
-    size: u64,
-}
 
 #[derive(Parser, Debug)]
 #[command(author, version, about)]
@@ -41,213 +15,32 @@ struct Args {
     output: String,
 }
 
-struct Dumper {
-    mmap: Mmap,
-    // !for Windows PE,
-    // - .rdata section
-    // !for Mach-O
-    // - __DATA segment, __const section
-    // - __DATA_CONST segment, __const section
-    sections: Vec<SectionInfo>,
-    binary_format: BinaryFormat,
-}
-
-impl Dumper {
-    fn new(file: File) -> Result<Self> {
-        let mmap = unsafe { Mmap::map(&file)? };
-        let obj = object::File::parse(&*mmap)?;
-        let binary_format = obj.format();
-
-        // find .rdata or similar section
-        let sections = match binary_format {
-            BinaryFormat::Pe => obj
-                .sections()
-                .filter(|s| s.name() == Ok(".rdata") && s.kind() == SectionKind::ReadOnlyData)
-                .map(|s| SectionInfo {
-                    virtual_address: s.address(),
-                    file_offset: s.file_range().unwrap().0,
-                    size: s.size(),
-                })
-                .collect::<Vec<_>>(),
-            BinaryFormat::MachO => obj
-                .sections()
-                .filter(|s| {
-                    s.segment_name() == Ok(Some("__TEXT"))
-                        || s.segment_name() == Ok(Some("__DATA_CONST"))
-                })
-                .filter(|s| s.name() == Ok("__const"))
-                .map(|s| SectionInfo {
-                    virtual_address: s.address(),
-                    file_offset: s.file_range().unwrap().0,
-                    size: s.size(),
-                })
-                .collect::<Vec<_>>(),
-            other_format => unimplemented!("Unsupport format: {:?}", other_format),
-        };
-
-        Ok(Self {
-            mmap,
-            sections,
-            binary_format,
-        })
-    }
-
-    fn convert_rva_to_file_offset(&self, rva: u64) -> Result<u64> {
-        let rva = match self.binary_format {
-            BinaryFormat::MachO => Ok(rva & 0xFFFFFFFFFFFF), // low 48 bit
-            BinaryFormat::Pe => {
-                let section = self.sections.first().context("")?;
-                if rva >= section.virtual_address && rva < section.virtual_address + section.size {
-                    Ok(rva - section.virtual_address + section.file_offset)
-                } else {
-                    Err(anyhow!("invalid rva: {:#X}", rva))
-                }
-            }
-            other_format => unimplemented!("Unsupport format: {:?}", other_format),
-        };
-
-        rva
-    }
-
-    fn heuristic_search_assets(&self) -> Result<Vec<Asset>> {
-        // get start offset and scan length
-        let (scan_start, scan_length) = match self.binary_format {
-            BinaryFormat::Pe => {
-                let section = self.sections.first().context("empty sections")?;
-                (section.file_offset as usize, section.size as usize)
-            }
-            BinaryFormat::MachO => {
-                // search range always in __DATA_CONST,__const section
-                let section = self.sections.last().context("empty sections")?;
-                (section.file_offset as usize, section.size as usize)
-            }
-            other_format => unimplemented!("Unsupport format: {:?}", other_format),
-        };
-
-        let end = scan_start.saturating_add(scan_length);
-        assert!(end <= self.mmap.len(), "scan end off is out of range");
-
-        let mut assets = Vec::new();
-        let mut offset = scan_start;
-        let mut scan_step = 8;
-        while offset + ASSET_HEADER_SIZE <= end {
-            if let Ok(asset) = self.parse_asset(offset) {
-                assets.push(asset);
-                scan_step = ASSET_HEADER_SIZE;
-            }
-
-            offset += scan_step;
-        }
-
-        Ok(assets)
-    }
-
-    fn parse_asset(&self, offset: usize) -> Result<Asset> {
-        if offset + ASSET_HEADER_SIZE > self.mmap.len() {
-            return Err(anyhow!("offset is out of range"));
-        }
-
-        let chunk = &self.mmap[offset..offset + ASSET_HEADER_SIZE];
-
-        let header = unsafe { &*(chunk.as_ptr() as *const AssetHeader) };
-
-        let name_off = self.convert_rva_to_file_offset(header.name_ptr)?;
-        let data_off = self.convert_rva_to_file_offset(header.data_ptr)?;
-
-        if !self.validate_asset_pointers(name_off, header.name_len, data_off, header.data_size) {
-            return Err(anyhow!("invalid asset pointers"));
-        }
-
-        let name = self.retrieve_asset_name(name_off as usize, header.name_len as usize)?;
-        let data = self.retrieve_asset_data(data_off as usize, header.data_size as usize)?;
-
-        Ok(Asset { name, data })
-    }
-
-    fn validate_asset_pointers(
-        &self,
-        name_ptr: u64,
-        name_len: u64,
-        data_ptr: u64,
-        data_size: u64,
-    ) -> bool {
-        let name_offset = name_ptr as usize;
-        let data_offset = data_ptr as usize;
-
-        // check if pointers are in the file range
-        if name_offset >= self.mmap.len()
-            || name_offset.saturating_add(name_len as usize) > self.mmap.len()
-            || data_offset >= self.mmap.len()
-            || data_offset.saturating_add(data_size as usize) > self.mmap.len()
-        {
-            return false;
-        }
-
-        // check name format
-        if self.mmap[name_offset] != b'/' {
-            return false;
-        }
-
-        // check brotli decompression
-        let mut decompressor = brotli::Decompressor::new(
-            &self.mmap[data_offset..data_offset + data_size as usize],
-            data_size as usize,
-        );
-        let mut decompressed = Vec::new();
-        decompressor.read_to_end(&mut decompressed).is_ok()
-    }
-
-    fn retrieve_asset_name(&self, offset: usize, len: usize) -> Result<String> {
-        let name = self.mmap[offset..offset + len].to_vec();
-        if !name.iter().all(|&b| b.is_ascii()) {
-            return Err(anyhow!("invalid name"));
-        }
-        let name = String::from_utf8(name)?;
-
-        Ok(name)
-    }
-
-    fn retrieve_asset_data(&self, offset: usize, len: usize) -> Result<Vec<u8>> {
-        Ok(self.mmap[offset..offset + len].to_vec())
-    }
-
-    fn decompress_asset(&self, asset: &Asset) -> Result<Vec<u8>> {
-        let reader = Cursor::new(&asset.data);
-        let mut decompressor = brotli::Decompressor::new(reader, asset.data.len());
-        let mut decompressed = Vec::new();
-        decompressor.read_to_end(&mut decompressed)?;
-        Ok(decompressed)
-    }
-}
-
 fn main() -> Result<()> {
     let args = Args::parse();
 
     let file = File::open(&args.input)?;
-
     let dumper = Dumper::new(file)?;
 
     println!("Scanning for assets...");
-    let assets = dumper.heuristic_search_assets()?;
+    let assets = dumper.scan_assets()?;
     println!("Scanning completed. Found {} assets", assets.len());
 
     if assets.is_empty() {
         return Err(anyhow!("No assets found"));
     }
 
-    // dump assets
     for asset in assets {
         let decompressed = dumper.decompress_asset(&asset)?;
 
-        // remove starts with /
-        let path = Path::new(&args.output).join(&asset.name[1..]);
+        // Remove leading '/'
+        let output = Path::new(&args.output).normalize();
+        let path = output.join(&asset.name[1..]).normalize();
 
-        // sanitize path
-        if !path.normalize().starts_with(&args.output) {
+        // Sanitize path to prevent traversal attacks
+        if !path.starts_with(&output) {
             return Err(anyhow!("Path traversal found: {:?}", path));
         }
 
-        // create parent directory if not exists
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent)?;
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,9 @@
 use anyhow::{anyhow, Result};
 use clap::Parser;
 use normalize_path::NormalizePath;
-use tauri_dumper::Dumper;
 use std::fs::{self, File};
 use std::path::Path;
+use tauri_dumper::Dumper;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about)]

--- a/tests/fixtures/fixtures.toml
+++ b/tests/fixtures/fixtures.toml
@@ -1,0 +1,68 @@
+# Test fixtures configuration
+# Used by: scripts/download-fixtures.sh, tests/integration_test.rs
+#
+# Each fixture tests a specific combination of:
+#   - format: Binary format (macho, pe, elf)
+#   - arch: CPU architecture (x64, aarch64)
+#
+# Expected values are tied to specific versions - update when changing versions!
+
+# =============================================================================
+# ChatWise
+# =============================================================================
+
+[[fixture]]
+name = "chatwise"
+format = "macho"
+arch = "aarch64"
+repo = "egoist/chatwise-releases"
+version = "v0.9.76"
+pattern = "ChatWise_aarch64.app.tar.gz"
+extract_dir = "chatwise_app"
+binary = "ChatWise.app/Contents/MacOS/ChatWise"
+description = "Mach-O with LC_DYLD_CHAINED_FIXUPS (modern format)"
+expected_asset_count = 197
+expected_index_html_size = 7678
+
+[[fixture]]
+name = "chatwise"
+format = "pe"
+arch = "x64"
+repo = "egoist/chatwise-releases"
+version = "v0.9.76"
+pattern = "ChatWise_0.9.76_x64-setup.exe"
+extract_dir = "chatwise_win"
+binary = "ChatWise.exe"
+description = "Windows PE (NSIS installer)"
+expected_asset_count = 198
+expected_index_html_size = 7691
+
+# =============================================================================
+# Antigravity Tools
+# =============================================================================
+
+[[fixture]]
+name = "antigravity"
+format = "macho"
+arch = "x64"
+repo = "lbjlaq/Antigravity-Manager"
+version = "v3.3.15"
+pattern = "Antigravity.Tools_x64.app.tar.gz"
+extract_dir = "antigravity_app"
+binary = "Antigravity Tools.app/Contents/MacOS/antigravity_tools"
+description = "Mach-O with LC_DYLD_INFO_ONLY (traditional format)"
+expected_asset_count = 6
+expected_index_html_size = 1984
+
+[[fixture]]
+name = "antigravity"
+format = "pe"
+arch = "x64"
+repo = "lbjlaq/Antigravity-Manager"
+version = "v3.3.15"
+pattern = "Antigravity.Tools_3.3.15_x64-setup.exe"
+extract_dir = "antigravity_win"
+binary = "antigravity_tools.exe"
+description = "Windows PE (NSIS installer)"
+expected_asset_count = 6
+expected_index_html_size = 1984

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -154,7 +154,11 @@ fn test_fixture(f: &Fixture) -> bool {
 fn test_all_fixtures() {
     let config = load_config();
     let total = config.fixture.len();
-    let tested: usize = config.fixture.iter().map(|f| test_fixture(f) as usize).sum();
+    let tested: usize = config
+        .fixture
+        .iter()
+        .map(|f| test_fixture(f) as usize)
+        .sum();
 
     // Ensure at least one fixture was tested if any binary exists
     let any_exists = config.fixture.iter().any(|f| f.binary_path().exists());

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,0 +1,191 @@
+//! Integration tests for tauri-dumper.
+//!
+//! These tests verify that the dumper works correctly across different:
+//!   - Binary formats (Mach-O, PE, ELF)
+//!   - CPU architectures (x64, aarch64)
+//!
+//! Fixtures are configured in `tests/fixtures/fixtures.toml`.
+//! For local testing, run: `./scripts/download-fixtures.sh`
+
+use std::fs::{self, File};
+use std::path::PathBuf;
+use std::sync::OnceLock;
+
+use serde::Deserialize;
+use tauri_dumper::Dumper;
+
+// ============================================================================
+// Configuration
+// ============================================================================
+
+#[derive(Debug, Deserialize)]
+struct Config {
+    fixture: Vec<Fixture>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Fixture {
+    name: String,
+    format: String,
+    arch: String,
+    version: String,
+    extract_dir: String,
+    binary: String,
+    expected_asset_count: usize,
+    expected_index_html_size: usize,
+}
+
+impl Fixture {
+    /// Unique identifier: `{name}-{format}-{arch}`
+    fn id(&self) -> String {
+        format!("{}-{}-{}", self.name, self.format, self.arch)
+    }
+
+    fn binary_path(&self) -> PathBuf {
+        fixture_dir().join(&self.extract_dir).join(&self.binary)
+    }
+}
+
+// ============================================================================
+// Logging
+// ============================================================================
+
+mod log {
+    pub fn skip(id: &str, reason: &str) {
+        eprintln!("⏭️  [{id}] Skipped: {reason}");
+    }
+
+    pub fn success(id: &str, version: &str, assets: usize, index_size: usize) {
+        eprintln!("✅ [{id}@{version}] {assets} assets, index.html = {index_size} bytes");
+    }
+}
+
+// ============================================================================
+// Infrastructure
+// ============================================================================
+
+fn fixture_dir() -> &'static PathBuf {
+    static DIR: OnceLock<PathBuf> = OnceLock::new();
+    DIR.get_or_init(|| PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures"))
+}
+
+fn load_config() -> &'static Config {
+    static CONFIG: OnceLock<Config> = OnceLock::new();
+    CONFIG.get_or_init(|| {
+        let path = fixture_dir().join("fixtures.toml");
+        let content = fs::read_to_string(&path).expect("Failed to read fixtures.toml");
+        toml::from_str(&content).expect("Failed to parse fixtures.toml")
+    })
+}
+
+// ============================================================================
+// Test Runner
+// ============================================================================
+
+/// Run asset extraction test on a single fixture.
+/// Returns `true` if tested, `false` if skipped (binary not found).
+fn test_fixture(f: &Fixture) -> bool {
+    let id = f.id();
+    let binary_path = f.binary_path();
+
+    if !binary_path.exists() {
+        log::skip(&id, "Binary not found. Run: ./scripts/download-fixtures.sh");
+        return false;
+    }
+
+    let file = File::open(&binary_path).unwrap_or_else(|e| panic!("[{id}] Open failed: {e}"));
+    let dumper = Dumper::new(file).unwrap_or_else(|e| panic!("[{id}] Dumper init failed: {e}"));
+    let assets = dumper
+        .scan_assets()
+        .unwrap_or_else(|e| panic!("[{id}] Scan failed: {e}"));
+
+    // Verify asset count
+    assert_eq!(
+        assets.len(),
+        f.expected_asset_count,
+        "[{id}] Asset count mismatch"
+    );
+
+    // Verify index.html
+    let index_html = assets
+        .iter()
+        .find(|a| a.name == "/index.html")
+        .unwrap_or_else(|| panic!("[{id}] index.html not found"));
+
+    let decompressed = dumper
+        .decompress_asset(index_html)
+        .unwrap_or_else(|e| panic!("[{id}] Decompress failed: {e}"));
+
+    assert_eq!(
+        decompressed.len(),
+        f.expected_index_html_size,
+        "[{id}] index.html size mismatch"
+    );
+
+    let content = String::from_utf8_lossy(&decompressed);
+    assert!(
+        content.contains("<!DOCTYPE") || content.contains("<html"),
+        "[{id}] Content doesn't look like HTML"
+    );
+
+    // Verify all asset paths are valid
+    for asset in &assets {
+        assert!(
+            asset.name.starts_with('/'),
+            "[{id}] Invalid path (no leading '/'): {}",
+            asset.name
+        );
+        assert!(
+            !asset.name.contains('\0'),
+            "[{id}] Path contains null byte: {}",
+            asset.name
+        );
+    }
+
+    log::success(&id, &f.version, assets.len(), decompressed.len());
+    true
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[test]
+fn test_all_fixtures() {
+    let config = load_config();
+    let total = config.fixture.len();
+    let tested: usize = config.fixture.iter().map(|f| test_fixture(f) as usize).sum();
+
+    // Ensure at least one fixture was tested if any binary exists
+    let any_exists = config.fixture.iter().any(|f| f.binary_path().exists());
+    if any_exists {
+        assert!(tested > 0, "All fixtures failed despite binaries existing");
+    }
+
+    eprintln!("📊 Summary: {tested}/{total} fixtures tested");
+}
+
+// ============================================================================
+// Edge Cases
+// ============================================================================
+
+mod edge_cases {
+    use super::*;
+
+    #[test]
+    fn reject_invalid_binary() {
+        let temp = tempfile::NamedTempFile::new().unwrap();
+        fs::write(temp.path(), b"not a valid binary").unwrap();
+
+        let file = File::open(temp.path()).unwrap();
+        assert!(Dumper::new(file).is_err());
+    }
+
+    #[test]
+    fn reject_empty_file() {
+        let temp = tempfile::NamedTempFile::new().unwrap();
+
+        let file = File::open(temp.path()).unwrap();
+        assert!(Dumper::new(file).is_err());
+    }
+}


### PR DESCRIPTION
### Summary

This PR introduces a major refactoring of the binary parsing layer and establishes a robust, configuration-driven testing framework.

### Changes

#### 🏗️ Architecture Refactoring

- **Trait-based binary parsing** (`src/binary/`)
  - `BinaryParser` trait abstracts format-specific logic
  - `MachOParser` - handles both `LC_DYLD_CHAINED_FIXUPS` and `LC_DYLD_INFO_ONLY`
  - `PeParser` - Windows PE support
  - Factory function `create_parser()` for automatic format detection

#### 🐛 Bug Fixes

- **Mach-O pointer resolution** - Fixed inconsistent behavior between:
  - Modern format (chained fixups): `target = (ptr & 0x7FFFFFFFFFF) + image_base`
  - Traditional format: `ptr` is the actual virtual address
- **Section detection** - Added support for `__DATA,__const` in addition to `__DATA_CONST,__const`

#### 🧪 Testing Infrastructure

- **Config-driven fixtures** (`tests/fixtures/fixtures.toml`) - single source of truth
- **Unified download script** (`scripts/download-fixtures.sh`)
- **Data-driven test runner** with automatic skip for missing fixtures

#### 🔄 CI/CD

- Consolidated workflows using reusable action
- Single test job downloads and tests all fixtures
- Fixture caching for faster runs

### Test Coverage

| Fixture | Format | Arch | Status |
|---------|--------|------|--------|
| [ChatWise](https://github.com/egoist/chatwise-releases) | Mach-O | aarch64 | ✅ |
| [ChatWise](https://github.com/egoist/chatwise-releases) | PE | x64 | ✅ |
| [Antigravity Tools](https://github.com/lbjlaq/Antigravity-Manager) | Mach-O | x64 | ✅ |
| [Antigravity Tools](https://github.com/lbjlaq/Antigravity-Manager) | PE | x64 | ✅ |

### Breaking Changes

None - public API unchanged.