### PR TITLE
feat: render asset list as tree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-dumper"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tauri-dumper"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["Mason Shi <fishilir@gmail.com>"]
 license = "MIT"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,8 +1,9 @@
 use anyhow::{Context, Result};
 use clap::{Args, Parser, Subcommand};
-use comfy_table::{presets::UTF8_FULL, Cell, Table};
+use comfy_table::{presets::UTF8_FULL, Table};
 use indicatif::{ProgressBar, ProgressStyle};
 use serde::Serialize;
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use tauri_dumper::asset::AssetTableSummary;
@@ -186,17 +187,7 @@ fn list(binary: &Path, common: &CommonArgs) -> Result<()> {
     if common.json {
         print_json(&table.summary())
     } else if !common.quiet {
-        let mut table_view = Table::new();
-        table_view.load_preset(UTF8_FULL);
-        table_view.set_header(vec!["Asset", "Compressed", "Decompressed"]);
-        for asset in table.assets() {
-            table_view.add_row(vec![
-                Cell::new(asset.name()),
-                Cell::new(asset.compressed_size()),
-                Cell::new(asset.decompressed_size()),
-            ]);
-        }
-        println!("{table_view}");
+        print_asset_tree(&table);
         Ok(())
     } else {
         Ok(())
@@ -322,6 +313,105 @@ fn finish_spinner(spinner: Option<ProgressBar>) {
 fn print_json<T: Serialize>(value: &T) -> Result<()> {
     println!("{}", serde_json::to_string_pretty(value)?);
     Ok(())
+}
+
+#[derive(Default)]
+struct AssetTreeNode {
+    children: BTreeMap<String, AssetTreeNode>,
+    asset: Option<AssetTreeLeaf>,
+}
+
+#[derive(Clone, Copy)]
+struct AssetTreeLeaf {
+    compressed_size: usize,
+    decompressed_size: usize,
+}
+
+fn print_asset_tree(table: &tauri_dumper::AssetTable) {
+    let mut root = AssetTreeNode::default();
+    for asset in table.assets() {
+        root.insert(
+            asset.name(),
+            AssetTreeLeaf {
+                compressed_size: asset.compressed_size(),
+                decompressed_size: asset.decompressed_size(),
+            },
+        );
+    }
+
+    println!("Assets: {}", table.len());
+    print_asset_tree_children(&root, "");
+}
+
+impl AssetTreeNode {
+    fn insert(&mut self, path: &str, asset: AssetTreeLeaf) {
+        let mut node = self;
+        for component in path
+            .trim_start_matches('/')
+            .split('/')
+            .filter(|component| !component.is_empty())
+        {
+            node = node.children.entry(component.to_string()).or_default();
+        }
+        node.asset = Some(asset);
+    }
+}
+
+fn print_asset_tree_children(node: &AssetTreeNode, prefix: &str) {
+    let child_count = node.children.len();
+    for (index, (name, child)) in node.children.iter().enumerate() {
+        let is_last = index + 1 == child_count;
+        let connector = if is_last {
+            "\u{2514}\u{2500}\u{2500} "
+        } else {
+            "\u{251c}\u{2500}\u{2500} "
+        };
+        println!(
+            "{}{}{}{}",
+            prefix,
+            connector,
+            name,
+            asset_tree_size_suffix(child.asset)
+        );
+
+        let next_prefix = if is_last {
+            format!("{prefix}    ")
+        } else {
+            format!("{prefix}\u{2502}   ")
+        };
+        print_asset_tree_children(child, &next_prefix);
+    }
+}
+
+fn asset_tree_size_suffix(asset: Option<AssetTreeLeaf>) -> String {
+    asset.map_or_else(String::new, |asset| {
+        format!(
+            " ({} compressed, {} decompressed)",
+            format_bytes(asset.compressed_size),
+            format_bytes(asset.decompressed_size)
+        )
+    })
+}
+
+fn format_bytes(bytes: usize) -> String {
+    const UNITS: [&str; 5] = ["B", "KiB", "MiB", "GiB", "TiB"];
+
+    if bytes < 1024 {
+        return format!("{bytes} B");
+    }
+
+    let mut value = bytes as f64;
+    let mut unit = 0;
+    while value >= 1024.0 && unit + 1 < UNITS.len() {
+        value /= 1024.0;
+        unit += 1;
+    }
+
+    if value < 10.0 {
+        format!("{value:.1} {}", UNITS[unit])
+    } else {
+        format!("{value:.0} {}", UNITS[unit])
+    }
 }
 
 fn print_inspect_summary(summary: &AssetTableSummary) {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,6 +1,7 @@
 mod common;
 
 use assert_cmd::Command;
+use predicates::prelude::*;
 use predicates::str::contains;
 use std::fs;
 
@@ -17,6 +18,26 @@ fn cli_lists_assets_as_json() {
         .success()
         .stdout(contains("\"asset_count\": 1"))
         .stdout(contains("/index.html"));
+}
+
+#[test]
+fn cli_lists_assets_as_tree() {
+    let temp = tempfile::tempdir().unwrap();
+    let input = temp.path().join("app");
+    fs::write(&input, common::nested_desktop_elf()).unwrap();
+
+    Command::cargo_bin("tauri-dumper")
+        .unwrap()
+        .args(["list", input.to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(contains("Assets: 3"))
+        .stdout(contains("\u{251c}\u{2500}\u{2500} _app"))
+        .stdout(contains("\u{2514}\u{2500}\u{2500} index.html"))
+        .stdout(contains("app.js ("))
+        .stdout(contains("compressed"))
+        .stdout(contains("Compressed").not())
+        .stdout(contains("Decompressed").not());
 }
 
 #[test]

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -48,6 +48,24 @@ pub fn load_config() -> &'static Config {
 }
 
 pub fn desktop_elf() -> Vec<u8> {
+    desktop_elf_with_assets(&[("/index.html", b"<!DOCTYPE html><html></html>" as &[u8])])
+}
+
+pub fn nested_desktop_elf() -> Vec<u8> {
+    desktop_elf_with_assets(&[
+        ("/index.html", b"<!DOCTYPE html><html></html>" as &[u8]),
+        (
+            "/_app/immutable/chunks/app.js",
+            b"console.log('app');" as &[u8],
+        ),
+        (
+            "/_app/immutable/assets/style.css",
+            b"body{color:#111}" as &[u8],
+        ),
+    ])
+}
+
+fn desktop_elf_with_assets(assets: &[(&str, &[u8])]) -> Vec<u8> {
     const ELF_HEADER_SIZE: usize = 64;
     const SECTION_HEADER_SIZE: usize = 64;
     const RODATA_ADDR: u64 = 0x400000;
@@ -56,19 +74,32 @@ pub fn desktop_elf() -> Vec<u8> {
     const DATA_REL_RO_OFF: usize = 0x2000;
     const SHSTRTAB_OFF: usize = 0x3000;
 
-    let html = b"<!DOCTYPE html><html></html>";
-    let compressed = brotli_compress(html);
-
     let mut rodata = Vec::new();
-    rodata.extend_from_slice(b"/index.html");
-    let data_addr = RODATA_ADDR + rodata.len() as u64;
-    rodata.extend_from_slice(&compressed);
+    let mut headers = Vec::new();
+    for (name, content) in assets {
+        let name_addr = RODATA_ADDR + rodata.len() as u64;
+        rodata.extend_from_slice(name.as_bytes());
 
-    let mut data_rel_ro = vec![0; 32];
-    write_u64(&mut data_rel_ro, 0, RODATA_ADDR);
-    write_u64(&mut data_rel_ro, 8, 11);
-    write_u64(&mut data_rel_ro, 16, data_addr);
-    write_u64(&mut data_rel_ro, 24, compressed.len() as u64);
+        let compressed = brotli_compress(content);
+        let data_addr = RODATA_ADDR + rodata.len() as u64;
+        rodata.extend_from_slice(&compressed);
+
+        headers.push((
+            name_addr,
+            name.len() as u64,
+            data_addr,
+            compressed.len() as u64,
+        ));
+    }
+
+    let mut data_rel_ro = vec![0; 32 * headers.len()];
+    for (index, (name_addr, name_len, data_addr, data_size)) in headers.into_iter().enumerate() {
+        let offset = index * 32;
+        write_u64(&mut data_rel_ro, offset, name_addr);
+        write_u64(&mut data_rel_ro, offset + 8, name_len);
+        write_u64(&mut data_rel_ro, offset + 16, data_addr);
+        write_u64(&mut data_rel_ro, offset + 24, data_size);
+    }
 
     let shstrtab = b"\0.rodata\0.data.rel.ro\0.shstrtab\0";
     let rodata_name = 1;


### PR DESCRIPTION
## Summary
- change human-readable list output from a table to a directory tree
- keep list --json output unchanged for automation
- add nested synthetic ELF coverage for tree rendering
- bump version to 0.2.1

## Validation
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace --all-targets -- --nocapture
- cargo test --release -- --nocapture
- cargo package --allow-dirty